### PR TITLE
Pv Validation

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -2,21 +2,22 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoVertex.PrimaryVertexProducer.TkClusParameters_cff import DA_vectParameters
 
+
 offlinePrimaryVertices = cms.EDProducer(
     "PrimaryVertexProducer",
 
     verbose = cms.untracked.bool(False),
     TrackLabel = cms.InputTag("generalTracks"),
     beamSpotLabel = cms.InputTag("offlineBeamSpot"),
-    
+
     TkFilterParameters = cms.PSet(
         algorithm=cms.string('filter'),
         maxNormalizedChi2 = cms.double(10.0),
         minPixelLayersWithHits=cms.int32(2),
         minSiliconLayersWithHits = cms.int32(5),
-        maxD0Significance = cms.double(4.0), 
-        maxD0Error = cms.double(1.0), 
-        maxDzError = cms.double(1.0), 
+        maxD0Significance = cms.double(4.0),
+        maxD0Error = cms.double(1.0),
+        maxDzError = cms.double(1.0),
         minPt = cms.double(0.0),
         maxEta = cms.double(2.4),
         trackQuality = cms.string("any")
@@ -41,12 +42,62 @@ offlinePrimaryVertices = cms.EDProducer(
                )
       ]
     ),
-    
+
     isRecoveryIteration = cms.bool(False),
     recoveryVtxCollection = cms.InputTag("")
 
-                                        
+
 )
+
+
+offlinePrimaryVerticesCUDA = cms.EDProducer(
+    "PrimaryVertexProducerCUDA",
+
+    verbose = cms.untracked.bool(False),
+    TrackLabel = cms.InputTag("generalTracks"),
+    beamSpotLabel = cms.InputTag("offlineBeamSpot"),
+    TkFilterParameters = cms.PSet(
+        algorithm=cms.string('filter'),
+        maxNormalizedChi2 = cms.double(10.0),
+        minPixelLayersWithHits=cms.int32(2),
+        minSiliconLayersWithHits = cms.int32(5),
+        maxD0Significance = cms.double(4.0),
+        maxD0Error = cms.double(1.0),
+        maxDzError = cms.double(1.0),
+        minPt = cms.double(0.0),
+        maxEta = cms.double(2.4),
+        trackQuality = cms.string("any")
+    ),
+
+    TkClusParameters = DA_vectParameters,
+    onGPU = cms.bool(True),
+
+    vertexCollections = cms.VPSet(
+     [cms.PSet(label=cms.string(""),
+               algorithm=cms.string("AdaptiveVertexFitter"),
+               chi2cutoff = cms.double(2.5),
+               minNdof=cms.double(0.0),
+               useBeamConstraint = cms.bool(False),
+               maxDistanceToBeam = cms.double(1.0)
+               ),
+      cms.PSet(label=cms.string("WithBS"),
+               algorithm = cms.string('AdaptiveVertexFitter'),
+               chi2cutoff = cms.double(2.5),
+               minNdof=cms.double(2.0),
+               useBeamConstraint = cms.bool(True),
+               maxDistanceToBeam = cms.double(1.0),
+               )
+      ]
+    ),
+
+    isRecoveryIteration = cms.bool(False),
+    recoveryVtxCollection = cms.InputTag("")
+
+
+)
+
+from Configuration.ProcessModifiers.gpu_cff import gpu
+gpu.toReplaceWith(offlinePrimaryVertices, offlinePrimaryVerticesCUDA.clone())
 
 # This customization is needed in the trackingLowPU era to be able to
 # produce vertices also in the cases in which the pixel detector is
@@ -59,8 +110,8 @@ trackingLowPU.toModify(offlinePrimaryVertices,
 
 
 # higher eta cut for the phase 2 tracker
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker 
-phase2_tracker.toModify(offlinePrimaryVertices, 
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(offlinePrimaryVertices,
                         TkFilterParameters = dict(maxEta = 4.0))
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
@@ -68,8 +119,8 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 (pp_on_XeXe_2017 | pp_on_AA).toModify(offlinePrimaryVertices,
                TkFilterParameters = dict(
                    maxD0Significance = 2.0,
-                   maxD0Error = 10.0, 
-                   maxDzError = 10.0, 
+                   maxD0Error = 10.0,
+                   maxDzError = 10.0,
                    minPixelLayersWithHits=3,
                    minPt = 0.7,
                    trackQuality = "highPurity"
@@ -77,11 +128,11 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
                TkClusParameters = cms.PSet(
             algorithm = cms.string("gap"),
             TkGapClusParameters = cms.PSet(
-                zSeparation = cms.double(1.0)        
+                zSeparation = cms.double(1.0)
                 )
             )
                )
-    
+
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
 highBetaStar_2018.toModify(offlinePrimaryVertices,
      TkFilterParameters = dict(
@@ -89,8 +140,8 @@ highBetaStar_2018.toModify(offlinePrimaryVertices,
          minPixelLayersWithHits = 1,
          minSiliconLayersWithHits = 3,
          maxD0Significance = 7.0,
-         maxD0Error = 10.0, 
-         maxDzError = 10.0, 
+         maxD0Error = 10.0,
+         maxDzError = 10.0,
          maxEta = 2.5
      ),
      vertexCollections = {
@@ -98,4 +149,3 @@ highBetaStar_2018.toModify(offlinePrimaryVertices,
          1: dict(chi2cutoff = 4.0, minNdof = -2.0),
      }
 )
-

--- a/RecoVertex/PrimaryVertexProducer/test/commons_cff.py
+++ b/RecoVertex/PrimaryVertexProducer/test/commons_cff.py
@@ -1,0 +1,90 @@
+import FWCore.ParameterSet.Config as cms
+
+## Validation step
+
+tpClusterProducer = cms.EDProducer("ClusterTPAssociationProducer",
+    mightGet = cms.optional.untracked.vstring,
+    phase2OTClusterSrc = cms.InputTag("siPhase2Clusters"),
+    phase2OTSimLinkSrc = cms.InputTag("simSiPixelDigis","Tracker"),
+    pixelClusterSrc = cms.InputTag("siPixelClusters"),
+    pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),
+    simTrackSrc = cms.InputTag("g4SimHits"),
+    stripClusterSrc = cms.InputTag("siStripClusters"),
+    stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
+    throwOnMissingCollections = cms.bool(True),
+    trackingParticleSrc = cms.InputTag("mix","MergedTrackTruth")
+)
+
+quickTrackAssociatorByHits = cms.EDProducer("QuickTrackAssociatorByHitsProducer",
+    AbsoluteNumberOfHits = cms.bool(False),
+    Cut_RecoToSim = cms.double(0.75),
+    PixelHitWeight = cms.double(1.0),
+    Purity_SimToReco = cms.double(0.75),
+    Quality_SimToReco = cms.double(0.5),
+    SimToRecoDenominator = cms.string('reco'),
+    ThreeHitTracksAreSpecial = cms.bool(True),
+    cluster2TPSrc = cms.InputTag("tpClusterProducer"),
+    useClusterTPAssociation = cms.bool(True)
+)
+
+VertexAssociatorByPositionAndTracks = cms.EDProducer("VertexAssociatorByPositionAndTracksProducer",
+    absT = cms.double(-1),
+    absZ = cms.double(0.1),
+    maxRecoT = cms.double(-1),
+    maxRecoZ = cms.double(1000),
+    mightGet = cms.optional.untracked.vstring,
+    sharedTrackFraction = cms.double(-1),
+    sigmaT = cms.double(-1),
+    sigmaZ = cms.double(3),
+    trackAssociation = cms.InputTag("trackingParticleRecoTrackAsssociation")
+)
+
+trackingParticleRecoTrackAsssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    associator = cms.InputTag("quickTrackAssociatorByHits"),
+    ignoremissingtrackcollection = cms.untracked.bool(False),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+    label_tr = cms.InputTag("generalTracks")
+)
+
+
+vertexAnalysis = cms.EDProducer("PrimaryVertexAnalyzer4PUSlimmed",
+    do_generic_sim_plots = cms.untracked.bool(True),
+    root_folder = cms.untracked.string('Vertexing/PrimaryVertexV'),
+    trackAssociatorMap = cms.untracked.InputTag("trackingParticleRecoTrackAsssociation"),
+    trackingParticleCollection = cms.untracked.InputTag("mix","MergedTrackTruth"),
+    trackingVertexCollection = cms.untracked.InputTag("mix","MergedTrackTruth"),
+    use_only_charged_tracks = cms.untracked.bool(True),
+    verbose = cms.untracked.bool(False),
+    vertexAssociator = cms.untracked.InputTag("VertexAssociatorByPositionAndTracks"),
+    vertexRecoCollections = cms.VInputTag("offlinePrimaryVertices")
+)
+
+
+## DQM step
+pvMonitor = cms.EDProducer("PrimaryVertexMonitor",
+    AlignmentLabel = cms.string('Alignment'),
+    DxyBin = cms.int32(100),
+    DxyMax = cms.double(5000.0),
+    DxyMin = cms.double(-5000.0),
+    DzBin = cms.int32(100),
+    DzMax = cms.double(2000.0),
+    DzMin = cms.double(-2000.0),
+    EtaBin = cms.int32(31),
+    EtaBin2D = cms.int32(8),
+    EtaMax = cms.double(3.0),
+    EtaMin = cms.double(-3.0),
+    PhiBin = cms.int32(32),
+    PhiBin2D = cms.int32(12),
+    PhiMax = cms.double(3.141592654),
+    PhiMin = cms.double(-3.141592654),
+    TkSizeBin = cms.int32(100),
+    TkSizeMax = cms.double(499.5),
+    TkSizeMin = cms.double(-0.5),
+    TopFolderName = cms.string('OfflinePV'),
+    Xpos = cms.double(0.1),
+    Ypos = cms.double(0.0),
+    beamSpotLabel = cms.InputTag("offlineBeamSpot"),
+    ndof = cms.int32(4),
+    useHPforAlignmentPlots = cms.bool(True),
+    vertexLabel = cms.InputTag("offlinePrimaryVertices")
+)

--- a/RecoVertex/PrimaryVertexProducer/test/commons_cff.py
+++ b/RecoVertex/PrimaryVertexProducer/test/commons_cff.py
@@ -56,7 +56,7 @@ vertexAnalysis = cms.EDProducer("PrimaryVertexAnalyzer4PUSlimmed",
     use_only_charged_tracks = cms.untracked.bool(True),
     verbose = cms.untracked.bool(False),
     vertexAssociator = cms.untracked.InputTag("VertexAssociatorByPositionAndTracks"),
-    vertexRecoCollections = cms.VInputTag("offlinePrimaryVertices")
+    vertexRecoCollections = cms.VInputTag("")
 )
 
 
@@ -86,5 +86,5 @@ pvMonitor = cms.EDProducer("PrimaryVertexMonitor",
     beamSpotLabel = cms.InputTag("offlineBeamSpot"),
     ndof = cms.int32(4),
     useHPforAlignmentPlots = cms.bool(True),
-    vertexLabel = cms.InputTag("offlinePrimaryVertices")
+    vertexLabel = cms.InputTag("")
 )

--- a/RecoVertex/PrimaryVertexProducer/test/cpuTest_cfg.py
+++ b/RecoVertex/PrimaryVertexProducer/test/cpuTest_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices
 process = cms.Process("Demo")
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) ) 
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load("TrackingTools/TransientTrack/TransientTrackBuilder_cfi")
 process.load("Configuration.Geometry.GeometryIdeal_cff")
@@ -9,6 +9,9 @@ process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 #process.load('HeterogeneousCore.CUDACore.ProcessAcceleratorCUDA_cfi')
 process.load("HeterogeneousCore.CUDAServices.CUDAService_cfi")
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('DQMServices.Core.DQMStoreNonLegacy_cff')
+process.load('validation_cff')
 
 #process.load( "HLTrigger.Timer.FastTimerService_cfi" )
 
@@ -26,10 +29,11 @@ process.IgProfService = cms.Service("IgProfService",
 )
 """
 process.source = cms.Source("PoolSource",
-# replace 'myfile.root' with the source file you want to use 
+# replace 'myfile.root' with the source file you want to use
 fileNames = cms.untracked.vstring(
-#'file:/afs/cern.ch/user/g/gpizzati/CMSSW_12_2_0_pre3/src/step2.root' 
-'/store/relval/CMSSW_12_2_0_pre3/RelValTTbar_14TeV/GEN-SIM-RECO/PU_122X_mcRun4_realistic_v2_2026D88PU200-v1/2580000/aca7b050-5990-4576-a9ee-f41ac82e5b86.root'
+#'file:/afs/cern.ch/user/g/gpizzati/CMSSW_12_2_0_pre3/src/step2.root'
+'file:aca7b050-5990-4576-a9ee-f41ac82e5b86.root'
+# /store/relval/CMSSW_12_2_0_pre3/RelValTTbar_14TeV/GEN-SIM-RECO/PU_122X_mcRun4_realistic_v2_2026D88PU200-v1/2580000/
 #'/store/relval/CMSSW_12_3_0_pre5/RelValTTbar_14TeV/GEN-SIM-RECO/123X_mcRun4_realistic_v4_2026D88noPU-v1/10000/7cbdf153-c397-410e-8af5-dc3905565ced.root'
 ),
 #firstEvent = cms.untracked.uint32(2)
@@ -69,11 +73,11 @@ process.demo = cms.EDProducer("PrimaryVertexProducer",
             delta_lowT = cms.double(1.e-3),   # convergence requirement at low T
             convergence_mode = cms.int32(0),  # 0 = two steps, 1 = dynamic with sqrt(T)
             Tmin = cms.double(2.0),           # end of vertex splitting
-            Tpurge = cms.double(2.0),         # cleaning 
-            Tstop = cms.double(0.5),          # end of annealing 
-            vertexSize = cms.double(0.006),   # added in quadrature to track-z resolutions        
-            d0CutOff = cms.double(3.),        # downweight high IP tracks 
-            dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)       
+            Tpurge = cms.double(2.0),         # cleaning
+            Tstop = cms.double(0.5),          # end of annealing
+            vertexSize = cms.double(0.006),   # added in quadrature to track-z resolutions
+            d0CutOff = cms.double(3.),        # downweight high IP tracks
+            dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)
             zmerge = cms.double(1e-2),        # merge intermediat clusters separated by less than zmerge
             uniquetrkweight = cms.double(0.8),# require at least two tracks with this weight at T=Tpurge
             uniquetrkminp = cms.double(0.0)   # minimal a priori track weight for counting unique tracks
@@ -84,9 +88,9 @@ process.demo = cms.EDProducer("PrimaryVertexProducer",
         maxNormalizedChi2 = cms.double(10.0),
         minPixelLayersWithHits=cms.int32(2),
         minSiliconLayersWithHits = cms.int32(5),
-        maxD0Significance = cms.double(4.0), 
-        maxD0Error = cms.double(1.0), 
-        maxDzError = cms.double(1.0), 
+        maxD0Significance = cms.double(4.0),
+        maxD0Error = cms.double(1.0),
+        maxDzError = cms.double(1.0),
         minPt = cms.double(0.0),
         maxEta = cms.double(2.4),
         trackQuality = cms.string("any")
@@ -125,13 +129,23 @@ process.demo = cms.EDProducer(
 )
 """
 
-process.out = cms.OutputModule("PoolOutputModule", 
-    fileName= cms.untracked.string("file:/eos/user/g/gpizzati/prim-vertex/test_cpu.root"),
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName= cms.untracked.string("file:test_cpu.root"),
     outputCommands = cms.untracked.vstring(
                                 'drop *_*_*_*',
                                 'keep *_demo_*_*'
     )
 )
 
+process.tracksValidationTruth = cms.Task(process.VertexAssociatorByPositionAndTracks, process.quickTrackAssociatorByHits, process.tpClusterProducer)
+process.pvValidation = cms.Sequence(process.vertexAnalysis,process.tracksValidationTruth)
+process.prevalidation_step = cms.Path(process.pvValidation)
+
+process.DQMOfflineVertex = cms.Sequence(process.pvMonitor)
+process.dqmoffline_step = cms.EndPath(process.DQMOfflineVertex)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
 process.p = cms.Path(process.demo)
 process.ep = cms.EndPath(process.out)
+
+process.schedule = cms.Schedule(process.p,process.prevalidation_step,process.dqmoffline_step,process.DQMoutput_step,process.ep)

--- a/RecoVertex/PrimaryVertexProducer/test/cudaTest_cfg.py
+++ b/RecoVertex/PrimaryVertexProducer/test/cudaTest_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVerticesCUDA_cfi import offlinePrimaryVertices
 process = cms.Process("Demo")
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) ) 
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load("TrackingTools/TransientTrack/TransientTrackBuilder_cfi")
 process.load("Configuration.Geometry.GeometryIdeal_cff")
@@ -10,8 +10,10 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 #process.load('HeterogeneousCore.CUDACore.ProcessAcceleratorCUDA_cfi')
 process.load("HeterogeneousCore.CUDAServices.CUDAService_cfi")
 process.load("HeterogeneousCore.CUDAServices.NVProfilerService_cfi")
-
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('DQMServices.Core.DQMStoreNonLegacy_cff')
 #process.load( "HLTrigger.Timer.FastTimerService_cfi" )
+process.load('validation_cff')
 
 #process.GlobalTag.globaltag = 'GR_P_V42_AN3::All'
 from Configuration.AlCa.GlobalTag import GlobalTag
@@ -27,10 +29,10 @@ process.IgProfService = cms.Service("IgProfService",
 )
 """
 process.source = cms.Source("PoolSource",
-# replace 'myfile.root' with the source file you want to use 
+# replace 'myfile.root' with the source file you want to use
 fileNames = cms.untracked.vstring(
-#'file:/afs/cern.ch/user/g/gpizzati/CMSSW_12_2_0_pre3/src/step2.root' 
-'/store/relval/CMSSW_12_2_0_pre3/RelValTTbar_14TeV/GEN-SIM-RECO/PU_122X_mcRun4_realistic_v2_2026D88PU200-v1/2580000/aca7b050-5990-4576-a9ee-f41ac82e5b86.root'
+#'file:/afs/cern.ch/user/g/gpizzati/CMSSW_12_2_0_pre3/src/step2.root'
+'file:aca7b050-5990-4576-a9ee-f41ac82e5b86.root'
 #'/store/relval/CMSSW_12_3_0_pre5/RelValTTbar_14TeV/GEN-SIM-RECO/123X_mcRun4_realistic_v4_2026D88noPU-v1/10000/7cbdf153-c397-410e-8af5-dc3905565ced.root'
 ),
 #firstEvent = cms.untracked.uint32(2)
@@ -72,11 +74,11 @@ process.demo = cms.EDProducer("PrimaryVertexProducer",
             delta_lowT = cms.double(1.e-3),   # convergence requirement at low T
             convergence_mode = cms.int32(0),  # 0 = two steps, 1 = dynamic with sqrt(T)
             Tmin = cms.double(2.0),           # end of vertex splitting
-            Tpurge = cms.double(2.0),         # cleaning 
-            Tstop = cms.double(0.5),          # end of annealing 
-            vertexSize = cms.double(0.006),   # added in quadrature to track-z resolutions        
-            d0CutOff = cms.double(3.),        # downweight high IP tracks 
-            dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)       
+            Tpurge = cms.double(2.0),         # cleaning
+            Tstop = cms.double(0.5),          # end of annealing
+            vertexSize = cms.double(0.006),   # added in quadrature to track-z resolutions
+            d0CutOff = cms.double(3.),        # downweight high IP tracks
+            dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)
             zmerge = cms.double(1e-2),        # merge intermediat clusters separated by less than zmerge
             uniquetrkweight = cms.double(0.8),# require at least two tracks with this weight at T=Tpurge
             uniquetrkminp = cms.double(0.0)   # minimal a priori track weight for counting unique tracks
@@ -87,9 +89,9 @@ process.demo = cms.EDProducer("PrimaryVertexProducer",
         maxNormalizedChi2 = cms.double(10.0),
         minPixelLayersWithHits=cms.int32(2),
         minSiliconLayersWithHits = cms.int32(5),
-        maxD0Significance = cms.double(4.0), 
-        maxD0Error = cms.double(1.0), 
-        maxDzError = cms.double(1.0), 
+        maxD0Significance = cms.double(4.0),
+        maxD0Error = cms.double(1.0),
+        maxDzError = cms.double(1.0),
         minPt = cms.double(0.0),
         maxEta = cms.double(2.4),
         trackQuality = cms.string("any")
@@ -127,13 +129,24 @@ process.demo = cms.EDProducer(
 
 )
 """
-process.out = cms.OutputModule("PoolOutputModule", 
-    fileName= cms.untracked.string("file:/eos/user/g/gpizzati/prim-vertex/test_gpu.root"),
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName= cms.untracked.string("file:test_gpu.root"),
     outputCommands = cms.untracked.vstring(
                                 'drop *_*_*_*',
                                 'keep *_demo_*_*'
     )
 )
 
+process.tracksValidationTruth = cms.Task(process.VertexAssociatorByPositionAndTracks, process.quickTrackAssociatorByHits, process.tpClusterProducer)
+process.pvValidation = cms.Sequence(process.vertexAnalysis,process.tracksValidationTruth)
+process.prevalidation_step = cms.Path(process.pvValidation)
+
+process.DQMOfflineVertex = cms.Sequence(process.pvMonitor)
+process.dqmoffline_step = cms.EndPath(process.DQMOfflineVertex)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
 process.p = cms.Path(process.demo)
 process.ep = cms.EndPath(process.out)
+
+process.schedule = cms.Schedule(process.p,process.prevalidation_step,process.dqmoffline_step,process.DQMoutput_step,process.ep)

--- a/RecoVertex/PrimaryVertexProducer/test/vertexTest.py
+++ b/RecoVertex/PrimaryVertexProducer/test/vertexTest.py
@@ -1,0 +1,193 @@
+import FWCore.ParameterSet.Config as cms
+from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices
+from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVerticesCUDA_cfi import offlinePrimaryVertices as offlinePrimaryVerticesCUDA
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+from HeterogeneousCore.CUDACore.SwitchProducerCUDA import SwitchProducerCUDA
+
+process = cms.Process("Vertexing")
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load("TrackingTools/TransientTrack/TransientTrackBuilder_cfi")
+process.load("Configuration.Geometry.GeometryIdeal_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load("HeterogeneousCore.CUDAServices.CUDAService_cfi")
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('DQMServices.Core.DQMStoreNonLegacy_cff')
+process.load('commons_cff')
+
+
+options = VarParsing.VarParsing('analysis')
+
+options.register ('n',
+                  10, # default value
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "n")
+options.register ('threads',
+                  4,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,
+                  "threads")
+options.register ('gpu',
+                  True,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.bool,
+                  "gpu")
+options.register ('timing',
+                  False,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.bool,
+                  "timing")
+options.register ('both',
+                  False,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.bool,
+                  "gpuVScpu")
+options.parseArguments()
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
+
+suff = 'gpu'
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(options.threads),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(True)
+)
+
+
+if not options.gpu:
+    process.options.accelerators = cms.untracked.vstring('cpu')
+    suff = 'cpu'
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(options.n))
+
+process.source = cms.Source("PoolSource",
+fileNames = cms.untracked.vstring(
+'file:aca7b050-5990-4576-a9ee-f41ac82e5b86.root'
+),
+skipEvents=cms.untracked.uint32(0)
+)
+
+if options.timing:
+
+    process.ThroughputService = cms.Service('ThroughputService',
+        eventRange = cms.untracked.uint32(10),
+        eventResolution = cms.untracked.uint32(1),
+        printEventSummary = cms.untracked.bool(True),
+        enableDQM = cms.untracked.bool(True),
+        dqmPathByProcesses = cms.untracked.bool(False),
+        dqmPath = cms.untracked.string('Throughput'),
+        timeRange = cms.untracked.double(1000),
+        timeResolution = cms.untracked.double(1)
+    )
+
+    process.MessageLogger.cerr.ThroughputService = cms.untracked.PSet(
+        limit = cms.untracked.int32(10000000)
+    )
+
+    process.FastTimerService.writeJSONSummary = cms.untracked.bool(True)
+    process.FastTimerService.jsonFileName = cms.untracked.string('resources_'+suff+'.json')
+
+    if not options.gpu:
+        process.IgProfService = cms.Service("IgProfService",
+          reportFirstEvent            = cms.untracked.int32(0),
+          reportEventInterval         = cms.untracked.int32(25),
+          reportToFileAtPostEvent     = cms.untracked.string("| gzip -c > igdqm.%I.gz")
+        )
+
+
+
+process.vertexing = offlinePrimaryVertices.clone()
+if options.gpu:
+    process.vertexing = offlinePrimaryVerticesCUDA.clone()
+
+if options.both:
+    suff = "gpuVScpu"
+
+process.output = cms.OutputModule("PoolOutputModule",
+    fileName= cms.untracked.string("file:test_gpu.root"),
+    outputCommands = cms.untracked.vstring(
+                                'drop *_*_*_*',
+                                'keep *_demo_*_*'
+    )
+)
+
+##DQM Output step
+process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('DQMIO'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('file:step3_inDQM.root'),
+    outputCommands = process.DQMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+process.output.fileName = 'file:test_'+suff+'.root'
+process.DQMoutput.fileName = 'file:test_dqm_'+suff+'.root'
+
+process.tracksValidationTruth = cms.Task(process.VertexAssociatorByPositionAndTracks, process.quickTrackAssociatorByHits, process.tpClusterProducer)
+process.pvValidation = cms.Sequence(process.vertexAnalysis,process.tracksValidationTruth)
+process.prevalidation_step = cms.Path(process.pvValidation)
+
+process.DQMOfflineVertex = cms.Sequence(process.pvMonitor)
+process.dqmoffline_step = cms.EndPath(process.DQMOfflineVertex)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+process.vertexing_step = cms.Path(process.vertexing)
+process.output_step = cms.EndPath(process.output)
+
+process.schedule = cms.Schedule(process.vertexing_step)
+
+if options.timing:
+
+    process.consumer = cms.EDAnalyzer("GenericConsumer", eventProducts = cms.untracked.vstring("offlinePrimaryVertices"))
+    process.consume_step = cms.EndPath(process.consumer)
+    process.schedule.append(process.consume_step)
+
+else:
+    process.schedule = cms.Schedule(process.vertexing_step,process.prevalidation_step,process.dqmoffline_step,process.DQMoutput_step,process.output_step)
+
+if options.both:
+
+    process.offlinePrimaryVertices = offlinePrimaryVertices.clone()
+    process.offlinePrimaryVerticesCUDA = offlinePrimaryVerticesCUDA.clone()
+    process.vertexing_step = cms.Path(process.offlinePrimaryVertices,process.offlinePrimaryVerticesCUDA)
+    process.consumerCPU = cms.EDAnalyzer("GenericConsumer", eventProducts = cms.untracked.vstring("offlinePrimaryVertices"))
+    process.consumerGPU = cms.EDAnalyzer("GenericConsumer", eventProducts = cms.untracked.vstring("offlinePrimaryVerticesCUDA"))
+    process.consume_step = cms.EndPath(process.consumerCPU,process.consumerGPU)
+
+    if not options.timing:
+        process.vertexAnalysis = cms.VInputTag("offlinePrimaryVertices","offlinePrimaryVerticesCUDA")
+
+    process.schedule.append(process.consume_step)


### PR DESCRIPTION
#### PR description:

PV validation:
- Adding a config to run CPU/GPU offline vertices reconstruction. This allows to run the PV monitoring and the validation from RECO samples. 
- Adding the possibility to use ‘gpu‘ procModifier to overwrite the `offlinePrimaryVertices` with `offlinePrimaryVerticesCUDA`. This means that one can run one of the wf in the matrix (such as e.g. `11634.1`) adding `--procModifiers gpu` to the RECO steps and it will run the vertexing on GPU.
